### PR TITLE
sdk: add request hook to fix API path

### DIFF
--- a/src/hooks/registration.ts
+++ b/src/hooks/registration.ts
@@ -1,14 +1,9 @@
+import { RewriteRequestPathHook } from "./request-path-hook";
 import { Hooks } from "./types";
 
-/*
- * This file is only ever generated once on the first generation and then is free to be modified.
- * Any hooks you wish to add should be registered in the initHooks function. Feel free to define them
- * in this file or in separate files in the hooks folder.
- */
-
-// @ts-expect-error remove this line when you add your first hook and hooks is used
 export function initHooks(hooks: Hooks) {
-    // Add hooks by calling hooks.register{ClientInit/BeforeRequest/AfterSuccess/AfterError}Hook
-    // with an instance of a hook that implements that specific Hook interface
-    // Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance
+  // Add hooks by calling hooks.register{ClientInit/BeforeRequest/AfterRequest/AfterError}Hook
+  // with an instance of a hook that implements that specific Hook interface
+  // Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance
+  hooks.registerBeforeRequestHook(new RewriteRequestPathHook());
 }

--- a/src/hooks/request-path-hook.ts
+++ b/src/hooks/request-path-hook.ts
@@ -2,6 +2,10 @@ import { BeforeRequestContext, BeforeRequestHook } from "./types";
 
 export class RewriteRequestPathHook implements BeforeRequestHook {
   beforeRequest(_hookCtx: BeforeRequestContext, request: Request): Request {
-    return new Request(decodeURIComponent(request.url), request);
+    const url = new URL(request.url);
+    if (url.pathname.startsWith("/v1/data")) {
+      return new Request(decodeURIComponent(request.url), request);
+    }
+    return request;
   }
 }

--- a/src/hooks/request-path-hook.ts
+++ b/src/hooks/request-path-hook.ts
@@ -1,0 +1,7 @@
+import { BeforeRequestContext, BeforeRequestHook } from "./types";
+
+export class RewriteRequestPathHook implements BeforeRequestHook {
+  beforeRequest(_hookCtx: BeforeRequestContext, request: Request): Request {
+    return new Request(decodeURIComponent(request.url), request);
+  }
+}


### PR DESCRIPTION
Due to a limitation in OpenAPI, we cannot use the generated client as-is to evaluate rules: `path: "foo/bar"` would end up as `POST /v1/data/foo%2fbar`, which OPA doesn't understand. This hook fixes the request path accordingly.

Should you want to query `data.foo["a/b"]`, the same approach still works -- `path: "foo/a%2fb"` would end up encoded twice, and the one decode in the hook causes the right request to be sent to OPA, `POST /v1/data/foo/a%2fb`.