### PR TITLE
bug(authorizer): actually account for ToInput implementations

### DIFF
--- a/src/sdk/helpers/authorizer.ts
+++ b/src/sdk/helpers/authorizer.ts
@@ -9,18 +9,30 @@ export interface ToInput {
   toInput(): Input;
 }
 
+function implementsToInput(object: any): object is ToInput {
+  const u = object as ToInput;
+  return u.toInput !== undefined && typeof u.toInput == "function";
+}
+
 export function authorizer<In extends Input | ToInput, Res>(
   sdk: Opa,
   path: string,
 ): (_?: In) => Promise<Res> {
   return async function (input?: In): Promise<Res> {
     let result: ExecutePolicyWithInputResponse | ExecutePolicyResponse;
+
     if (input === undefined) {
       result = await sdk.executePolicy({ path });
     } else {
+      let inp: Input;
+      if (implementsToInput(input)) {
+        inp = input.toInput();
+      } else {
+        inp = input;
+      }
       result = await sdk.executePolicyWithInput({
         path,
-        requestBody: { input },
+        requestBody: { input: inp },
       });
     }
     if (!result.successfulPolicyEvaluation) throw `no result in API response`;

--- a/tests/authorizer.test.ts
+++ b/tests/authorizer.test.ts
@@ -102,21 +102,46 @@ it_is := true
     assert.deepStrictEqual(res, { type: "boolean" });
   });
 
-  it("supports input class implementing ToInput", async () => {
-    class A implements ToInput {
-      private name: string;
-      private list: any[];
+  it("calls stringify on a class as input", async () => {
+    class A {
+      // These are so that JSON.stringify() returns the right thing.
+      name: string;
+      list: any[];
 
       constructor(name: string, list: any[]) {
         this.name = name;
         this.list = list;
       }
+    }
+    const inp = new A("alice", [1, 2, true]);
+
+    interface myResult {
+      foo: string;
+    }
+    const res = await authorizer<A, myResult>(
+      new Opa({ serverURL }),
+      "test/compound_input",
+    )(inp);
+    assert.deepStrictEqual(res, { foo: "bar" });
+  });
+
+  it("supports input class implementing ToInput", async () => {
+    class A implements ToInput {
+      // These are so that JSON.stringify() doesn't return the right thing.
+      private n: string;
+      private l: any[];
+
+      constructor(name: string, list: any[]) {
+        this.n = name;
+        this.l = list;
+      }
 
       toInput(): Input {
-        return { name: this.name, list: this.list };
+        return { name: this.n, list: this.l };
       }
     }
     const inp = new A("alice", [1, 2, true]);
+
     interface myResult {
       foo: string;
     }


### PR DESCRIPTION
Before, this had accidentally worked in the test case because
- the object (instance of class A) had passed through the zod validation
- and its JSON.stringify happened to be the right format

Now, the test cases are better capturing the intent.