### PR TITLE
ci: publish to npm

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,19 @@
+name: Publish
+
+# Will trigger when the RELEASES.md file is updated by the merged PR from the generation workflow
+# NOTE(sr): Let's use this for a start and see if we need to adjust later on.
+on:
+  workflow_dispatch: {}
+  push:
+    paths:
+      - "RELEASES.md"
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the sdk publish workflow which will handle the publishing to the package managers
+    with:
+      publish_typescript: true
+    secrets:
+      npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The NPM_TOKEN secret is invalid -- I'll fix that later.