### PR TITLE
.npmignore: add .github and .speakeasy

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,5 @@
 
 /.eslintrc.js
 /cjs
+/.github
+/.speakeasy


### PR DESCRIPTION
It seems like we cannot get rid of this
<img width="799" alt="image" src="https://github.com/StyraInc/opa-typescript/assets/870638/8c3bcf88-6295-4a36-a36f-15b3bf4fbf12">
([see here](https://www.npmjs.com/package/@styra/opa/v/0.2.5?activeTab=code))

because npm has a hardcoded rule _never_ to exclude README files, even if they are in `.npmignore`. 🤷 