### PR TITLE
README.md: tweak note/information blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ The Styra-supported driver to connect to Open Policy Agent (OPA) and Enterprise 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![NPM Version](https://img.shields.io/npm/v/%40styra%2Fopa?style=flat&color=%2324b6e0)](https://www.npmjs.com/package/@styra/opa)
 
-> [!IMPORTANT]
 > The documentation for this SDK lives at https://docs.styra.com/sdk, with reference documentation available at https://styrainc.github.io/opa-typescript
 
 You can use the Styra OPA SDK to connect to [Open Policy Agent](https://www.openpolicyagent.org/) and [Enterprise OPA](https://www.styra.com/enterprise-opa/) deployments.
@@ -251,8 +250,7 @@ export class CatsController {
 
 Please refer to [the repository's README.md](https://github.com/StyraInc/opa-typescript-example-nestjs/tree/main#opa-typescript-nestjs-example) for more details.
 
-> [!NOTE]
-> For low-level SDK usage, see the sections below.
+> **Note**: For low-level SDK usage, see the sections below.
 
 ---
 

--- a/typedoc.config.cjs
+++ b/typedoc.config.cjs
@@ -19,20 +19,14 @@ module.exports = {
   excludeInternal: true,
   excludePrivate: true,
   excludeProtected: true,
-  // excludeNotDocumented: true,
   entryPointStrategy: "resolve",
-  // readme: "./README.md",
   plugin: ["typedoc-plugin-replace-text", "typedoc-plugin-extras"],
   favicon: "./.typedoc/favicon.ico",
   replaceText: {
     replacements: [
       { pattern: "# OPA Typescript SDK", replace: "" },
       {
-        pattern: `> \\[!NOTE\\]`,
-        replace: "",
-      },
-      {
-        pattern: `> For low-level SDK usage, see the sections below.\n\n---`,
+        pattern: `> \\*\\*Note\\*\\*: For low-level SDK usage, see the sections below.`,
         replace: "",
       },
       {


### PR DESCRIPTION
The README is rendered in three places:
- https://github.com/StyraInc/opa-typescript?tab=readme-ov-file#opa-typescript-sdk
- https://styrainc.github.io/opa-typescript/
- https://www.npmjs.com/package/@styra/opa

The github-specific note/information markup won't work on the other places. So removing it for clarity.