### PR TITLE
OpaApiClient: fix request path hook to work with proxies

### DIFF
--- a/src/hooks/request-path-hook.ts
+++ b/src/hooks/request-path-hook.ts
@@ -7,7 +7,7 @@ export class RewriteRequestPathHook implements BeforeCreateRequestHook {
     input: RequestInput,
   ): RequestInput {
     const url = new URL(input.url);
-    if (url.pathname.startsWith("/v1/data")) {
+    if (url.pathname.indexOf("/v1/data/") != -1) {
       url.pathname = decodeURIComponent(url.pathname);
       return { ...input, url };
     }


### PR DESCRIPTION
Before, our workaround (in the hook) would fail to pick up an executePolicy call to a serverURL with a prefix, like `https://your-unified-api-gateway/opa`.

Now, it'll check if it finds "/v1/data/" anywhere in the request path, and adjusts it accordingly.

It would have been nicer if we had access to the serverURL's prefix, but that's not available in the hook, as far as I can tell.