### PR TITLE
OPAClient: convert last argument into options grab-bag

### DIFF
--- a/src/opaclient.ts
+++ b/src/opaclient.ts
@@ -6,6 +6,7 @@ import {
 } from "./sdk/models/operations";
 import { SDKOptions } from "./lib/config";
 import { HTTPClient } from "./lib/http";
+import { RequestOptions as FetchOptions } from "./lib/sdks";
 
 export type { Input, Result };
 
@@ -27,6 +28,14 @@ function implementsToInput(object: any): object is ToInput {
 export type Options = {
   headers?: Record<string, string>;
   sdk?: SDKOptions;
+};
+
+/** Extra per-request options for using the high-level SDK's
+ * evaluate/evaluateDefault methods.
+ */
+export type RequestOptions<Res> = {
+  request?: FetchOptions;
+  fromResult?: (res?: Result) => Res;
 };
 
 /** OPAClient is the starting point for using the high-level API.
@@ -60,17 +69,19 @@ export class OPAClient {
    *
    * @param path - The path to the policy, without `/v1/data`: use `authz/allow` to evaluate policy `data.authz.allow`.
    * @param input - The input to the policy, if needed.
-   * @param fromResult - A function that is used to transform the policy evaluation result (which could be `undefined`).
+   * @param opts - Per-request options: `fromResult`, a function that is used to transform the
+   * policy evaluation result (which could be `undefined`), and `request` for low-level
+   * fetch options.
    */
   async evaluate<In extends Input | ToInput, Res>(
     path: string,
     input?: In,
-    fromResult?: (res?: Result) => Res,
+    opts?: RequestOptions<Res>,
   ): Promise<Res> {
     let result: ExecutePolicyWithInputResponse | ExecutePolicyResponse;
 
     if (input === undefined) {
-      result = await this.opa.executePolicy({ path });
+      result = await this.opa.executePolicy({ path }, opts?.request);
     } else {
       let inp: Input;
       if (implementsToInput(input)) {
@@ -78,32 +89,44 @@ export class OPAClient {
       } else {
         inp = input;
       }
-      result = await this.opa.executePolicyWithInput({
-        path,
-        requestBody: { input: inp },
-      });
+      result = await this.opa.executePolicyWithInput(
+        {
+          path,
+          requestBody: { input: inp },
+        },
+        opts?.request,
+      );
     }
     if (!result.successfulPolicyEvaluation) throw `no result in API response`;
     const res = result.successfulPolicyEvaluation.result;
+    const fromResult = opts?.fromResult;
     return fromResult ? fromResult(res) : (res as Res);
   }
 
   /** `evaluateDefault` is used to evaluate the server's default policy with optional input.
    *
    * @param input - The input to the default policy, defaults to `{}`.
-   * @param fromResult - A function that is used to transform the policy evaluation result (which could be `undefined`).
+   * @param opts - Per-request options: `fromResult`, a function that is used to transform the
+   * policy evaluation result (which could be `undefined`), and `request` for low-level
+   * fetch options.
    */
   async evaluateDefault<In extends Input | ToInput, Res>(
     input?: In,
-    fromResult?: (res?: Result) => Res,
+    opts?: RequestOptions<Res>,
   ): Promise<Res> {
     let inp = input ?? {};
     if (implementsToInput(inp)) {
       inp = inp.toInput();
     }
-    const resp = await this.opa.executeDefaultPolicyWithInput(inp);
+    const resp = await this.opa.executeDefaultPolicyWithInput(
+      inp,
+      undefined, // pretty
+      undefined, // gzipEncoding
+      opts?.request,
+    );
     if (!resp.result) throw `no result in API response`;
     const res = resp.result;
+    const fromResult = opts?.fromResult;
     return fromResult ? fromResult(res) : (res as Res);
   }
 }

--- a/tests/authorizer.test.ts
+++ b/tests/authorizer.test.ts
@@ -255,7 +255,7 @@ allow if {
     const signal = AbortSignal.abort();
     assert.rejects(
       new OPAClient(serverURL).evaluate("test/p_bool", undefined, {
-        request: { fetchOptions: { signal } },
+        fetchOptions: { signal },
       }),
     );
   });

--- a/tests/authorizer.test.ts
+++ b/tests/authorizer.test.ts
@@ -229,7 +229,10 @@ allow if {
     const res = await new OPAClient(serverURL).evaluate<any, boolean>(
       "test/compound_result",
       undefined, // input
-      (r?: Result) => (r as Record<string, any>)["allowed"] ?? false,
+      {
+        fromResult: (r?: Result) =>
+          (r as Record<string, any>)["allowed"] ?? false,
+      },
     );
     assert.deepStrictEqual(res, true);
   });
@@ -246,6 +249,15 @@ allow if {
     }).evaluate("test/p_bool");
     assert.strictEqual(res, true);
     assert.strictEqual(called, true);
+  });
+
+  it("allows fetch options", async () => {
+    const signal = AbortSignal.abort();
+    assert.rejects(
+      new OPAClient(serverURL).evaluate("test/p_bool", undefined, {
+        request: { fetchOptions: { signal } },
+      }),
+    );
   });
 
   it("allows custom headers", async () => {


### PR DESCRIPTION
...allowing the control of low-level fetch() options, too.